### PR TITLE
Add Next.js ShadCN demo with dashboard graphs and table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# ShadCN Next.js Example
+
+This project demonstrates a simple Next.js app using the App Router, TypeScript, and [ShadCN UI](https://ui.shadcn.com/). It includes a persistent sidebar, dashboard graphs using Chart.js, and a data table with sorting, filtering and pagination.
+
+## Setup
+
+1. **Install dependencies**
+
+```bash
+npm install
+```
+
+2. **Run the development server**
+
+```bash
+npm run dev
+```
+
+Open `http://localhost:3000` in your browser.
+
+## Dependencies
+
+- `next` & `react` – framework and React runtime
+- `@shadcn/ui` – UI components styled with Tailwind CSS
+- `@faker-js/faker` – fake data generation
+- `react-chartjs-2` & `chart.js` – chart components
+- `@tanstack/react-table` – table utilities
+- `tailwindcss` – styling
+
+## Suggestions
+
+- Extract more UI components for reuse as the application grows.
+- Configure ESLint and Prettier for consistent code style.
+- Add authentication and API routes for real data.

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,14 @@
+import { GraphCard } from '../../components/GraphCard';
+import { generateChartData } from '../../lib/data';
+
+export default function DashboardPage() {
+  const data = generateChartData();
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <GraphCard title="Line Chart" type="line" data={data} />
+      <GraphCard title="Bar Chart" type="bar" data={data} />
+      <GraphCard title="Pie Chart" type="pie" data={data} />
+    </div>
+  );
+}

--- a/app/data/page.tsx
+++ b/app/data/page.tsx
@@ -1,0 +1,17 @@
+import { DataTable } from '../../components/DataTable';
+import { generateTableData, DataRow } from '../../lib/data';
+import { ColumnDef } from '@tanstack/react-table';
+
+const columns: ColumnDef<DataRow>[] = [
+  { accessorKey: 'id', header: 'ID' },
+  { accessorKey: 'name', header: 'Name' },
+  { accessorKey: 'age', header: 'Age' },
+  { accessorKey: 'birthday', header: 'Birthday' },
+  { accessorKey: 'active', header: 'Active', cell: info => String(info.getValue()) },
+  { accessorKey: 'visits', header: 'Visits' },
+];
+
+export default function DataPage() {
+  const data = generateTableData(25);
+  return <DataTable data={data} columns={columns} />;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,9 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  margin: 0;
+  font-family: sans-serif;
+  min-height: 100vh;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,16 @@
+import './globals.css';
+import type { ReactNode } from 'react';
+import { SideNav } from '../components/SideNav';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="flex">
+        <SideNav />
+        <main className="flex-1 p-4 overflow-y-auto">
+          {children}
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Page() {
+  redirect('/dashboard');
+}

--- a/components/DataTable.tsx
+++ b/components/DataTable.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  SortingState,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Input, Button } from '@shadcn/ui';
+
+interface Props<T> {
+  data: T[];
+  columns: ColumnDef<T, any>[];
+}
+
+export function DataTable<T>({ data, columns }: Props<T>) {
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [filter, setFilter] = useState('');
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { sorting, globalFilter: filter },
+    onSortingChange: setSorting,
+    onGlobalFilterChange: setFilter,
+    globalFilterFn: 'auto',
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+  });
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <Input
+          placeholder="Filter..."
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
+      </div>
+      <div className="overflow-auto">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map(hg => (
+              <TableRow key={hg.id}>
+                {hg.headers.map(header => (
+                  <TableHead
+                    key={header.id}
+                    onClick={header.column.getToggleSortingHandler()}
+                    className="cursor-pointer select-none"
+                  >
+                    {flexRender(header.column.columnDef.header, header.getContext())}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows.map(row => (
+              <TableRow key={row.id}>
+                {row.getVisibleCells().map(cell => (
+                  <TableCell key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-between">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          Previous
+        </Button>
+        <span>
+          Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
+        </span>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/GraphCard.tsx
+++ b/components/GraphCard.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@shadcn/ui';
+import { Line, Bar, Pie } from 'react-chartjs-2';
+import type { ChartData, ChartOptions } from 'chart.js';
+import { CategoryScale, LinearScale, PointElement, LineElement, BarElement, ArcElement, Tooltip, Legend } from 'chart.js';
+import { Chart } from 'chart.js';
+
+Chart.register(CategoryScale, LinearScale, PointElement, LineElement, BarElement, ArcElement, Tooltip, Legend);
+
+interface Props {
+  title: string;
+  type: 'line' | 'bar' | 'pie';
+  data: ChartData;
+  options?: ChartOptions;
+}
+
+export function GraphCard({ title, type, data, options }: Props) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {type === 'line' && <Line data={data} options={options} />}
+        {type === 'bar' && <Bar data={data} options={options} />}
+        {type === 'pie' && <Pie data={data} options={options} />}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/SideNav.tsx
+++ b/components/SideNav.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { cn } from '@shadcn/ui';
+
+export function SideNav() {
+  const pathname = usePathname();
+
+  const links = [
+    { href: '/dashboard', label: 'Dashboard' },
+    { href: '/data', label: 'Data' },
+  ];
+
+  return (
+    <nav className="w-48 h-screen border-r p-4 flex flex-col space-y-2">
+      {links.map(link => (
+        <Link
+          key={link.href}
+          href={link.href}
+          className={cn(
+            'px-3 py-2 rounded-md hover:bg-muted',
+            pathname === link.href && 'bg-muted font-medium'
+          )}
+        >
+          {link.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,0 +1,36 @@
+import { faker } from '@faker-js/faker';
+
+export function generateChartData() {
+  const labels = Array.from({ length: 7 }, () => faker.date.recent().toLocaleDateString());
+  return {
+    labels,
+    datasets: [
+      {
+        label: 'Sales',
+        data: labels.map(() => faker.number.int({ min: 0, max: 100 })),
+        backgroundColor: 'rgba(59, 130, 246, 0.5)',
+        borderColor: 'rgb(59,130,246)',
+      },
+    ],
+  };
+}
+
+export interface DataRow {
+  id: number;
+  name: string;
+  age: number;
+  birthday: string;
+  active: boolean;
+  visits: number;
+}
+
+export function generateTableData(count = 20): DataRow[] {
+  return Array.from({ length: count }).map((_, i) => ({
+    id: i + 1,
+    name: faker.person.fullName(),
+    age: faker.number.int({ min: 18, max: 80 }),
+    birthday: faker.date.birthdate().toLocaleDateString(),
+    active: faker.datatype.boolean(),
+    visits: faker.number.int({ min: 0, max: 1000 }),
+  }));
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "shadcn-next-app",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@shadcn/ui": "^0.1.0",
+    "@faker-js/faker": "^8.0.1",
+    "react-chartjs-2": "^5.2.0",
+    "chart.js": "^4.3.0",
+    "@tanstack/react-table": "^8.5.12"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "tailwindcss": "^3.3.2",
+    "postcss": "^8.4.21",
+    "autoprefixer": "^10.4.13"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js app with TS, Tailwind, ShadCN UI
- add chart components with Chart.js using faker data
- implement data table with sorting/filtering/paging
- provide setup instructions and suggestions in README

## Testing
- `git status --short`