### PR TITLE
Fix local UI module to resolve imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ShadCN Next.js Example
 
-This project demonstrates a simple Next.js app using the App Router, TypeScript, and [ShadCN UI](https://ui.shadcn.com/). It includes a persistent sidebar, dashboard graphs using Chart.js, and a data table with sorting, filtering and pagination.
+This project demonstrates a simple Next.js app using the App Router, TypeScript,. It includes a persistent sidebar, dashboard graphs using Chart.js, and a data table with sorting, filtering and pagination.
 
 ## Setup
 
@@ -21,7 +21,7 @@ Open `http://localhost:3000` in your browser.
 ## Dependencies
 
 - `next` & `react` – framework and React runtime
-- `@shadcn/ui` – UI components styled with Tailwind CSS
+- Custom UI components built with Tailwind CSS
 - `@faker-js/faker` – fake data generation
 - `react-chartjs-2` & `chart.js` – chart components
 - `@tanstack/react-table` – table utilities

--- a/components/DataTable.tsx
+++ b/components/DataTable.tsx
@@ -11,7 +11,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Input, Button } from '@shadcn/ui';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Input, Button } from './ui';
 
 interface Props<T> {
   data: T[];

--- a/components/GraphCard.tsx
+++ b/components/GraphCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Card, CardContent, CardHeader, CardTitle } from '@shadcn/ui';
+import { Card, CardContent, CardHeader, CardTitle } from './ui';
 import { Line, Bar, Pie } from 'react-chartjs-2';
 import type { ChartData, ChartOptions } from 'chart.js';
 import { CategoryScale, LinearScale, PointElement, LineElement, BarElement, ArcElement, Tooltip, Legend } from 'chart.js';

--- a/components/SideNav.tsx
+++ b/components/SideNav.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { cn } from '@shadcn/ui';
+import { cn } from './ui';
 
 export function SideNav() {
   const pathname = usePathname();

--- a/components/ui.tsx
+++ b/components/ui.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { forwardRef } from 'react';
+
+export function cn(...classes: (string | undefined | null | false)[]): string {
+  return classes.filter(Boolean).join(' ');
+}
+
+export function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('rounded border bg-white shadow', className)} {...props} />;
+}
+
+export function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('border-b p-4', className)} {...props} />;
+}
+
+export function CardTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return <h3 className={cn('text-lg font-medium', className)} {...props} />;
+}
+
+export function CardContent({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('p-4', className)} {...props} />;
+}
+
+export function Table({ className, ...props }: React.HTMLAttributes<HTMLTableElement>) {
+  return <table className={cn('w-full text-left border-collapse', className)} {...props} />;
+}
+
+export function TableHeader({ className, ...props }: React.HTMLAttributes<HTMLTableSectionElement>) {
+  return <thead className={cn('bg-gray-100', className)} {...props} />;
+}
+
+export function TableBody({ className, ...props }: React.HTMLAttributes<HTMLTableSectionElement>) {
+  return <tbody className={className} {...props} />;
+}
+
+export function TableRow({ className, ...props }: React.HTMLAttributes<HTMLTableRowElement>) {
+  return <tr className={cn('border-b', className)} {...props} />;
+}
+
+export function TableHead({ className, ...props }: React.ThHTMLAttributes<HTMLTableHeaderCellElement>) {
+  return <th className={cn('p-2 text-left font-medium', className)} {...props} />;
+}
+
+export function TableCell({ className, ...props }: React.TdHTMLAttributes<HTMLTableDataCellElement>) {
+  return <td className={cn('p-2', className)} {...props} />;
+}
+
+export const Input = forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(function Input(
+  { className, ...props },
+  ref
+) {
+  return <input ref={ref} className={cn('border rounded p-2', className)} {...props} />;
+});
+
+export const Button = forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(function Button(
+  { className, ...props },
+  ref
+) {
+  return <button ref={ref} className={cn('px-3 py-1 border rounded', className)} {...props} />;
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "next": "14.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "@shadcn/ui": "^0.1.0",
     "@faker-js/faker": "^8.0.1",
     "react-chartjs-2": "^5.2.0",
     "chart.js": "^4.3.0",


### PR DESCRIPTION
## Summary
- remove `@shadcn/ui` dependency
- replace all imports of `@shadcn/ui` with a local `components/ui` implementation
- create minimal UI components and `cn` utility
- update README to mention custom UI components

## Testing
- `npm test` *(fails: Missing script)*