### PR TITLE
Remove deprecated config and fix data page

### DIFF
--- a/app/data/page.tsx
+++ b/app/data/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { DataTable } from '../../components/DataTable';
 import { generateTableData, DataRow } from '../../lib/data';
 import { ColumnDef } from '@tanstack/react-table';

--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  experimental: {
-    appDir: true
-  }
+  // All features used are stable, so the experimental.appDir setting is no longer needed
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- remove `appDir` from `next.config.js`
- mark `/data` page as a client component

## Testing
- `npm run build` *(fails: next not found)*