### PR TITLE
Add sidebar and agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENT Guidance
+
+This repository contains a small Next.js application using the App Router and Tailwind CSS. Components are written in TypeScript under the `components/` directory and pages live under `app/`.
+
+## Conventions
+- Use TypeScript for all React components.
+- Keep components in the `components/` folder. Shared UI primitives live under `components/ui`.
+- Pages and layouts should be placed in the `app/` directory following Next.js routing conventions.
+- Use the utility `cn` from `components/ui.tsx` to compose Tailwind CSS class names.
+
+## Development
+- Install dependencies with `npm install` (requires network access).
+- Run the development server with `npm run dev`.
+- Build for production using `npm run build`.
+
+No automated tests are configured. If you add new dependencies, update `package.json` accordingly.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,12 @@
 import './globals.css';
 import type { ReactNode } from 'react';
-import { SideNav } from '../components/SideNav';
+import { AppSidebar } from '../components/AppSidebar';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body className="flex">
-        <SideNav />
+        <AppSidebar />
         <main className="flex-1 p-4 overflow-y-auto">
           {children}
         </main>

--- a/components/AppSidebar.tsx
+++ b/components/AppSidebar.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import * as React from 'react';
+import {
+  ArrowUpCircleIcon,
+  BarChartIcon,
+  CameraIcon,
+  ClipboardListIcon,
+  DatabaseIcon,
+  FileCodeIcon,
+  FileIcon,
+  FileTextIcon,
+  FolderIcon,
+  HelpCircleIcon,
+  LayoutDashboardIcon,
+  ListIcon,
+  SearchIcon,
+  SettingsIcon,
+  UsersIcon,
+} from './icons';
+
+import { NavDocuments } from './nav-documents';
+import { NavMain } from './nav-main';
+import { NavSecondary } from './nav-secondary';
+import { NavUser } from './nav-user';
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from './ui/sidebar';
+
+const data = {
+  user: {
+    name: 'shadcn',
+    email: 'm@example.com',
+    avatar: '/avatars/shadcn.jpg',
+  },
+  navMain: [
+    { title: 'Dashboard', url: '#', icon: LayoutDashboardIcon },
+    { title: 'Lifecycle', url: '#', icon: ListIcon },
+    { title: 'Analytics', url: '#', icon: BarChartIcon },
+    { title: 'Projects', url: '#', icon: FolderIcon },
+    { title: 'Team', url: '#', icon: UsersIcon },
+  ],
+  navClouds: [
+    {
+      title: 'Capture',
+      icon: CameraIcon,
+      isActive: true,
+      url: '#',
+      items: [
+        { title: 'Active Proposals', url: '#' },
+        { title: 'Archived', url: '#' },
+      ],
+    },
+    {
+      title: 'Proposal',
+      icon: FileTextIcon,
+      url: '#',
+      items: [
+        { title: 'Active Proposals', url: '#' },
+        { title: 'Archived', url: '#' },
+      ],
+    },
+    {
+      title: 'Prompts',
+      icon: FileCodeIcon,
+      url: '#',
+      items: [
+        { title: 'Active Proposals', url: '#' },
+        { title: 'Archived', url: '#' },
+      ],
+    },
+  ],
+  navSecondary: [
+    { title: 'Settings', url: '#', icon: SettingsIcon },
+    { title: 'Get Help', url: '#', icon: HelpCircleIcon },
+    { title: 'Search', url: '#', icon: SearchIcon },
+  ],
+  documents: [
+    { name: 'Data Library', url: '#', icon: DatabaseIcon },
+    { name: 'Reports', url: '#', icon: ClipboardListIcon },
+    { name: 'Word Assistant', url: '#', icon: FileIcon },
+  ],
+};
+
+export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+  return (
+    <Sidebar collapsible="offcanvas" {...props}>
+      <SidebarHeader>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton asChild className="data-[slot=sidebar-menu-button]:!p-1.5">
+              <a href="#">
+                <ArrowUpCircleIcon className="h-5 w-5" />
+                <span className="text-base font-semibold">Acme Inc.</span>
+              </a>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
+      <SidebarContent>
+        <NavMain items={data.navMain} />
+        <NavDocuments items={data.documents} />
+        <NavSecondary items={data.navSecondary} className="mt-auto" />
+      </SidebarContent>
+      <SidebarFooter>
+        <NavUser user={data.user} />
+      </SidebarFooter>
+    </Sidebar>
+  );
+}

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+
+function IconPlaceholder({ className }: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className={className}>
+      <circle cx="12" cy="12" r="10" />
+    </svg>
+  );
+}
+
+export const ArrowUpCircleIcon = IconPlaceholder;
+export const BarChartIcon = IconPlaceholder;
+export const CameraIcon = IconPlaceholder;
+export const ClipboardListIcon = IconPlaceholder;
+export const DatabaseIcon = IconPlaceholder;
+export const FileCodeIcon = IconPlaceholder;
+export const FileIcon = IconPlaceholder;
+export const FileTextIcon = IconPlaceholder;
+export const FolderIcon = IconPlaceholder;
+export const HelpCircleIcon = IconPlaceholder;
+export const LayoutDashboardIcon = IconPlaceholder;
+export const ListIcon = IconPlaceholder;
+export const SearchIcon = IconPlaceholder;
+export const SettingsIcon = IconPlaceholder;
+export const UsersIcon = IconPlaceholder;

--- a/components/nav-documents.tsx
+++ b/components/nav-documents.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import Link from 'next/link';
+import * as React from 'react';
+import { cn } from './ui';
+
+export interface DocumentItem {
+  name: string;
+  url: string;
+  icon?: React.ComponentType<{ className?: string }>;
+}
+
+export function NavDocuments({ items, className }: { items: DocumentItem[]; className?: string }) {
+  return (
+    <div className={cn('flex flex-col gap-1', className)}>
+      <p className="px-3 text-xs font-semibold uppercase text-gray-500">Documents</p>
+      {items.map((item) => (
+        <Link key={item.name} href={item.url} className="flex items-center gap-2 rounded px-3 py-2 hover:bg-muted">
+          {item.icon && <item.icon className="h-4 w-4" />}
+          <span>{item.name}</span>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/components/nav-main.tsx
+++ b/components/nav-main.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import * as React from 'react';
+import { cn } from './ui';
+
+export interface NavItem {
+  title: string;
+  url: string;
+  icon?: React.ComponentType<{ className?: string }>;
+}
+
+export function NavMain({ items, className }: { items: NavItem[]; className?: string }) {
+  const pathname = usePathname();
+  return (
+    <nav className={cn('flex flex-col gap-1', className)}>
+      {items.map((item) => (
+        <Link
+          key={item.title}
+          href={item.url}
+          className={cn(
+            'flex items-center gap-2 rounded px-3 py-2 hover:bg-muted',
+            pathname === item.url && 'bg-muted font-medium'
+          )}
+        >
+          {item.icon && <item.icon className="h-4 w-4" />}
+          <span>{item.title}</span>
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/components/nav-secondary.tsx
+++ b/components/nav-secondary.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import * as React from 'react';
+import { cn } from './ui';
+
+export interface NavItem {
+  title: string;
+  url: string;
+  icon?: React.ComponentType<{ className?: string }>;
+}
+
+export function NavSecondary({ items, className }: { items: NavItem[]; className?: string }) {
+  const pathname = usePathname();
+  return (
+    <nav className={cn('flex flex-col gap-1', className)}>
+      {items.map((item) => (
+        <Link
+          key={item.title}
+          href={item.url}
+          className={cn(
+            'flex items-center gap-2 rounded px-3 py-2 hover:bg-muted',
+            pathname === item.url && 'bg-muted font-medium'
+          )}
+        >
+          {item.icon && <item.icon className="h-4 w-4" />}
+          <span>{item.title}</span>
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/components/nav-user.tsx
+++ b/components/nav-user.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from './ui';
+
+export interface User {
+  name: string;
+  email: string;
+  avatar: string;
+}
+
+export function NavUser({ user, className }: { user: User; className?: string }) {
+  return (
+    <div className={cn('flex items-center gap-3', className)}>
+      <img src={user.avatar} alt="avatar" className="h-8 w-8 rounded-full" />
+      <div className="text-sm">
+        <p className="font-medium leading-none">{user.name}</p>
+        <p className="text-xs text-gray-500">{user.email}</p>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '../ui';
+
+export interface SidebarProps extends React.HTMLAttributes<HTMLElement> {
+  collapsible?: string;
+}
+
+export function Sidebar({ className, ...props }: SidebarProps) {
+  return (
+    <aside
+      className={cn('flex h-screen w-64 flex-col border-r bg-white', className)}
+      {...props}
+    />
+  );
+}
+
+export function SidebarHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('border-b p-4', className)} {...props} />;
+}
+
+export function SidebarContent({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('flex flex-1 flex-col gap-4 overflow-y-auto p-4', className)} {...props} />;
+}
+
+export function SidebarFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('mt-auto border-t p-4', className)} {...props} />;
+}
+
+export function SidebarMenu({ className, ...props }: React.HTMLAttributes<HTMLUListElement>) {
+  return <ul className={cn('flex flex-col gap-2', className)} {...props} />;
+}
+
+export function SidebarMenuItem({ className, ...props }: React.HTMLAttributes<HTMLLIElement>) {
+  return <li className={className} {...props} />;
+}
+
+export const SidebarMenuButton = React.forwardRef<HTMLAnchorElement, React.HTMLAttributes<HTMLAnchorElement>>(function SidebarMenuButton({ className, ...props }, ref) {
+  return (
+    <a
+      ref={ref}
+      className={cn('flex items-center gap-2 rounded px-2 py-1 hover:bg-muted', className)}
+      {...props}
+    />
+  );
+});


### PR DESCRIPTION
## Summary
- implement ShadCN style sidebar and nav components
- update layout to use new `AppSidebar`
- add placeholder icons and sidebar primitives
- document repo usage in new `AGENTS.md`

## Testing
- `npm run build` *(fails: `next` not found)*